### PR TITLE
Fixed ClassCastException on casting Context to Activity

### DIFF
--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/CardListFragment.java
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/CardListFragment.java
@@ -104,7 +104,7 @@ public class CardListFragment extends Fragment implements AdapterView.OnItemClic
     private static class CardsAdapter extends BaseAdapter {
 
         private List<Item> items = new ArrayList<>();
-        private Context context;
+        private Activity context;
         private CardLogoCache cardLogoCache;
 
         public CardsAdapter(Activity context) {
@@ -167,7 +167,7 @@ public class CardListFragment extends Fragment implements AdapterView.OnItemClic
                 String name = card.getPan();
                 ((ImageView) (convertView.findViewById(R.id.iv_icon))).setImageBitmap(cardLogoCache.getLogoByNumber(context, name));
                 ((TextView) (convertView.findViewById(R.id.tv_card_name))).setText(name);
-                convertView.findViewById(R.id.iv_daw).setVisibility(((PayFormActivity)convertView.getContext()).getSourceCard() == card ? View.VISIBLE : View.GONE);
+                convertView.findViewById(R.id.iv_daw).setVisibility(((PayFormActivity) context).getSourceCard() == card ? View.VISIBLE : View.GONE);
                 return convertView;
             } else if (type == Item.NEW_CARD) {
                 if (convertView == null) {

--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/EnterCardFragment.java
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/EnterCardFragment.java
@@ -149,7 +149,9 @@ public class EnterCardFragment extends Fragment implements EditCardView.Actions,
                     return;
                 }
 
-                Card srcCard = ((PayFormActivity) v.getContext()).getSourceCard();
+                final PayFormActivity activity = (PayFormActivity) getActivity();
+
+                Card srcCard = activity.getSourceCard();
                 CardData cardData = null;
 
                 if (srcCard == null) {
@@ -160,7 +162,7 @@ public class EnterCardFragment extends Fragment implements EditCardView.Actions,
                     cardData = new CardData(cardId, cvc);
                 }
 
-                ((PayFormActivity) getActivity()).showProgressDialog();
+                activity.showProgressDialog();
                 initPayment(sdk, orderId, customerKey, title, amount, cardData, enteredEmail, reccurentPayment);
             }
         });


### PR DESCRIPTION
ClassCastException occurs on API 23, e.g. when android.support.v7.widget.TintContextWrapper wraps the original Activity context.