### PR TITLE
Удаление SECURE_LOGOS из обязательных параметров

### DIFF
--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/inflate/attach/AttachCellInflater.java
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/inflate/attach/AttachCellInflater.java
@@ -43,7 +43,7 @@ public class AttachCellInflater {
     }
 
     public View inflate(ViewGroup container) {
-        validate(PAYMENT_CARD_REQUISITES, ATTACH_BUTTON, SECURE_LOGOS);
+        validate(PAYMENT_CARD_REQUISITES, ATTACH_BUTTON);
 
         View root = inflater.inflate(R.layout.acq_fragment_attach_card_base, container, false);
         container = root.findViewById(R.id.ll_container_layout);

--- a/ui/src/main/java/ru/tinkoff/acquiring/sdk/inflate/pay/PayCellInflater.java
+++ b/ui/src/main/java/ru/tinkoff/acquiring/sdk/inflate/pay/PayCellInflater.java
@@ -44,7 +44,7 @@ public class PayCellInflater {
     }
 
     public View inflate(ViewGroup container) {
-        validate(PAYMENT_CARD_REQUISITES, PAY_BUTTON, SECURE_LOGOS);
+        validate(PAYMENT_CARD_REQUISITES, PAY_BUTTON);
 
         View root = inflater.inflate(R.layout.acq_fragment_enter_card_base, container, false);
         container = root.findViewById(R.id.ll_container_layout);


### PR DESCRIPTION
В ios asdk SECURE_LOGOS не является обязательным параметром, чтобы иметь одинаковые интерфейсы на обоих платформ нужна возможность скрывать SECURE_LOGOS на android