### PR TITLE
AttachCardFormActivity bug with empty text

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
         <activity
             android:name=".AttachCardFormActivity"
-            android:theme="@style/AcquiringTheme" />
+            android:theme="@style/AcquiringAttachCardTheme" />
 
     </application>
 

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -37,6 +37,7 @@
     <string name="acq_no_scan_providers">Отсутвуют провайдеры для сканирования</string>
     <string name="acq_complete_payment">Для совершения платежа, введите CVC</string>
     <string name="acq_complete_payment_ok">ОК</string>
+    <string name="acq_attach_card">Привязать карту</string>
 
     <string-array name="acq_scan_types">
         <item>Сканировать камерой</item>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -36,6 +36,7 @@
     <string name="acq_no_scan_providers">There aren\'t any providers</string>
     <string name="acq_complete_payment">To complete payment, enter CVC</string>
     <string name="acq_complete_payment_ok">OK</string>
+    <string name="acq_attach_card">Attach card</string>
 
     <string-array name="acq_scan_types">
         <item>Scan with camera</item>

--- a/ui/src/main/res/values/styles.xml
+++ b/ui/src/main/res/values/styles.xml
@@ -35,7 +35,10 @@
         <item name="acqPayButtonAndIconPosition">buttonUnderFieldsIconsOnBottom</item>
         <item name="acqPayWithAmountFormat">@string/acq_pay_with_amount</item>
         <item name="acqMoneyAmountFormat">@string/acq_money_amount_format</item>
+    </style>
 
+    <style name="AcquiringAttachCardTheme" parent="AcquiringTheme">
+        <item name="acqButtonStyle">@style/AcquiringAttachButtonStyle</item>
     </style>
 
     <style name="AcquiringNfcTheme" parent="AcquiringTheme">
@@ -164,6 +167,10 @@
 
     <style name="AcquiringPaySecureIconStyle">
         <item name="android:src">@drawable/acq_logos_bottom</item>
+    </style>
+
+    <style name="AcquiringAttachButtonStyle" parent="AcquiringButtonStyle">
+        <item name="android:text">@string/acq_attach_card</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Fixed problems with empty text on AttachCardFormActivity when setTheme is not called